### PR TITLE
項順序周りを少し修正

### DIFF
--- a/lib/poly_ruby/monomial.rb
+++ b/lib/poly_ruby/monomial.rb
@@ -351,14 +351,16 @@ class Monomial
   #  0: self=m
   # -1: m ≺ self
   def revlex(m)
-    i = VarOrder.size - 1
-    while i >= 0
-      if @power[VarOrder[i]] != m.power[VarOrder[i]]
-        return -(@power[VarOrder[i]] <=> m.power[VarOrder[i]])
+    ret = 0
+    lhs = @power
+    rhs = m.power
+    for var in VarOrder.reverse
+      if lhs[var].to_i - rhs[var].to_i != 0
+        ret = -(lhs[var].to_i <=> rhs[var].to_i)
+        break
       end
-      i = i - 1
     end
-    return 0
+    ret
   end
 
   # degree lexicographic order(全次数辞書式順序)

--- a/lib/poly_ruby/monomial.rb
+++ b/lib/poly_ruby/monomial.rb
@@ -369,7 +369,7 @@ class Monomial
   # -1: m ≺ self
   def deglex(m)
     t1 = self.total_degree; t2 = m.total_degree
-    if t1 != t2; return -(t1 <=> t2); end
+    if t1 != t2; return t1 <=> t2; end
     return self.lex(m)
   end
 
@@ -379,7 +379,7 @@ class Monomial
   # -1: m ≺ self
   def degrevlex(m)
     t1 = self.total_degree; t2 = m.total_degree
-    if t1 != t2; return -(t1 <=> t2); end
+    if t1 != t2; return t1 <=> t2; end
     return self.revlex(m)
   end
 

--- a/lib/poly_ruby/monomial.rb
+++ b/lib/poly_ruby/monomial.rb
@@ -29,7 +29,7 @@
 #               "prog"      "5*x**4+3*x**2+1"
 # Monomial.set_term_order(t)
 # Monomial.get_term_order
-#        t= "lex"(default), "deglex",  "degrevlex"
+#        t= :lex(default), :deglex,  :degrevlex
 #        set/get term order
 # Monomial.set_var_order(order)
 # Monomial.get_var_order
@@ -138,11 +138,13 @@ class Monomial
 
   def lcm(other) # lcm of power product
     m = Monomial.new(1, {})
-    VarOrder.each { |v|
-      d = [@power[v], other.power[v]].max
-      #if m != nil
+    lhs_power = @power.dup
+    rhs_power = other.power.dup
+    var_order = lhs_power.keys.concat(rhs_power.keys.dup).uniq
+
+    var_order.each { |v|
+      d = [power[v], other.power[v]].max
       m.power[v] = d
-      #end
     }
     return m
   end
@@ -151,9 +153,7 @@ class Monomial
     m = Monomial.new(1, {})
     VarOrder.each { |v|
       d = [@power[v], other.power[v]].min
-      #if m != 0
       m.power[v] = d
-      #end
     }
     return m
   end
@@ -301,9 +301,9 @@ class Monomial
   #  deglex(degreeLexicographical)
   #  degrevlex(degreeReverseLexicographical)
 
-  TermOrder = ["lex"] # "lex" "deglex" "degrevlex"
+  TermOrder = [:lex] # :lex :deglex :degrevlex
 
-  def Monomial.set_term_order(t = "lex") # t= "lex" "deglex" "degrevlex"
+  def Monomial.set_term_order(t = :lex) # t= :lex :deglex :degrevlex
     TermOrder[0] = t
   end
 
@@ -327,15 +327,29 @@ class Monomial
     if !VarOrder.include?(v); VarOrder.push(v); end
   end
 
-  def lex(m) #lexical order
-    for i in 0..VarOrder.size - 1
-      if @power[VarOrder[i]] != m.power[VarOrder[i]]
-        return @power[VarOrder[i]] <=> m.power[VarOrder[i]]
+  # lexicographic order(辞書式順序)
+  #  1: self ≺ m
+  #  0: self=m
+  # -1: m ≺ self
+  #
+  #  1 ≺ y ≺ y^2 ≺ ... ≺ x ≺ xy ≺ xy^2 ≺ ... x^2 ≺ x^2y ≺ ... x^3 ...
+  def lex(m)
+    ret = 0
+    lhs = @power
+    rhs = m.power
+    for var in VarOrder
+      if lhs[var].to_i - rhs[var].to_i != 0
+        ret = lhs[var].to_i <=> rhs[var].to_i
+        break
       end
     end
-    return 0
+    ret
   end
 
+  # reverse lexicographic order(逆辞書式順序)
+  #  1: self ≺ m
+  #  0: self=m
+  # -1: m ≺ self
   def revlex(m)
     i = VarOrder.size - 1
     while i >= 0
@@ -347,24 +361,37 @@ class Monomial
     return 0
   end
 
+  # degree lexicographic order(全次数辞書式順序)
+  #  1: self ≺ m
+  #  0: self=m
+  # -1: m ≺ self
   def deglex(m)
     t1 = self.total_degree; t2 = m.total_degree
-    if t1 != t2; return t1 <=> t2; end
+    if t1 != t2; return -(t1 <=> t2); end
     return self.lex(m)
   end
 
+  # degree reverse lexicographic order(全次数逆辞書式順序)
+  #  1: self ≺ m
+  #  0: self=m
+  # -1: m ≺ self
   def degrevlex(m)
     t1 = self.total_degree; t2 = m.total_degree
-    if t1 != t2; return t1 <=> t2; end
+    if t1 != t2; return -(t1 <=> t2); end
     return self.revlex(m)
   end
 
-  # 1: self>m, 0: self=m, -1: self<m
-  def <=>(m)
-    case TermOrder[0]
-    when "lex"; return self.lex(m)
-    when "deglex"; return self.deglex(m)
-    when "degrevlex"; return self.degrevlex(m)
+  #  1: self ≺ m; self > m
+  #  0: self=m  ; self ==m
+  # -1: m ≺ self; self < m
+  def <=>(m, term_order=:lex)
+    case term_order
+    when :lex
+      return self.lex(m)
+    when :deglex
+      return self.deglex(m)
+    when :degrevlex
+      return self.degrevlex(m)
     end
   end
 

--- a/lib/poly_ruby/polynomialm.rb
+++ b/lib/poly_ruby/polynomialm.rb
@@ -196,8 +196,12 @@ class PolynomialM # Polynomial of Multi Variable
 
     # 同類項をまとめる.
     @monomials = @monomials.group_by{|m| m.power}.map do |power,terms|
-      ans = terms.inject(:+)
-      ans
+      m = terms.inject(:+)
+      if m.coeff == 0
+        nil # 係数0の項を除く
+      else
+        m
+      end
     end
     @monomials.compact!
     self.sort!
@@ -219,8 +223,8 @@ class PolynomialM # Polynomial of Multi Variable
 
     # 同類項をまとめる.
     monomials = monomials.group_by{|m| m.power}.map do |power,terms|
-      ans = terms.inject(:+)
-      ans
+      m = terms.inject(:+)
+      m
     end
     monomials.compact!
     return monomials
@@ -366,7 +370,7 @@ class PolynomialM # Polynomial of Multi Variable
   end
 
   def -(other)
-    return self + (-other)
+    self + (-other)
   end
 
   def *(other)

--- a/lib/poly_ruby/polynomialm.rb
+++ b/lib/poly_ruby/polynomialm.rb
@@ -110,6 +110,7 @@ def P_.method_missing(*a)
   PolynomialM(a[0].id2name)
 end
 
+
 def PolynomialM(poly_arg1 = 0, *poly_arg2)
   case poly_arg1
   when PolynomialM
@@ -224,7 +225,7 @@ class PolynomialM # Polynomial of Multi Variable
     monomials.compact!
   end
 
-  def lt # leading term
+  def lt # LT(Leading Term)
     if self.zero?
       return Monomial(0)
     else
@@ -232,13 +233,18 @@ class PolynomialM # Polynomial of Multi Variable
     end
   end
 
-  def lc # leading coefficient
+  def lc # LC(Leading Coefficient)
     if self.zero?
       return 0
     else
       return @monomials[0].coeff
     end
   end
+
+  # HT(Head Term)
+  alias_method :ht, :lt
+  # HT(Head Coefficient)
+  alias_method :hc, :lc
 
   def lp # leading power product
     if self.zero?; return Monomial(1) else return @monomials[0].power_product end
@@ -287,8 +293,8 @@ class PolynomialM # Polynomial of Multi Variable
     return deg
   end
 
-  def sort! # decreasing order. higher term is top.
-    @monomials.sort! { |m1, m2| m2 <=> m1 }
+  def sort!(term_order=:lex) # decreasing order. higher term is top.
+    @monomials.sort! { |m1, m2| m2.<=>(m1, term_order) }
   end
 
   def zero?
@@ -634,6 +640,7 @@ class PolynomialM # Polynomial of Multi Variable
       return sprintf "PolynomialM([%s])", @monomials.join(",")
     end
   end
+
 end #PolynomialM
 
 # alias

--- a/lib/poly_ruby/polynomialm.rb
+++ b/lib/poly_ruby/polynomialm.rb
@@ -223,6 +223,7 @@ class PolynomialM # Polynomial of Multi Variable
       ans
     end
     monomials.compact!
+    return monomials
   end
 
   def lt # LT(Leading Term)
@@ -372,10 +373,12 @@ class PolynomialM # Polynomial of Multi Variable
     if other.kind_of?(PolynomialM)
       multiplied = self.monomials.map do |sm|
         other.monomials.map do |om|
-          sm * om
+          mul = sm * om
+          mul
         end
       end.inject([]) { |sum, m| sum.concat(m) }
-      return PolynomialM(multiplied)
+
+      return PolynomialM(self.normalize(multiplied))
     elsif other.kind_of?(Numeric)
       p = self.clone
       p.monomials.each { |m| m.coeff *= other }

--- a/spec/poly_ruby/monomial_spec.rb
+++ b/spec/poly_ruby/monomial_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require "poly_ruby/monomial"
 
 
@@ -12,12 +13,43 @@ RSpec.describe Monomial do
     expect(Monomial(c=2, p={"x"=>0}).to_s).to eq "2"
   end
   it "can get/set term order" do
-    Monomial.set_term_order("lex")
-    expect(Monomial.get_term_order).to eq "lex"
-    Monomial.set_term_order("deglex")
-    expect(Monomial.get_term_order).to eq "deglex"
-    Monomial.set_term_order("degrevlex")
-    expect(Monomial.get_term_order).to eq "degrevlex"
+    Monomial.set_term_order(:lex)
+    expect(Monomial.get_term_order).to eq :lex
+    Monomial.set_term_order(:deglex)
+    expect(Monomial.get_term_order).to eq :deglex
+    Monomial.set_term_order(:degrevlex)
+    expect(Monomial.get_term_order).to eq :degrevlex
+  end
+
+  describe "#lex(m)" do
+
+    context "Give 1 or 2 variable, use lexicographic order" do
+      it "1 -< y; 1 > y = True" do
+        expect(Monomial(c=1).lex(Monomial(c=1, p={"y"=>1}))).to eq 1
+      end
+      it "y -< y^2; y > y^2 = True" do
+        expect(Monomial(c=1, p={"y"=>1}).lex(Monomial(c=1, p={"y"=>2}))).to eq 1
+      end
+      it "x -< y; x > y = True" do
+        expect(Monomial(c=1, p={"x"=>1}).lex(Monomial(c=1, p={"y"=>1}))).to eq 1
+      end
+      it "x -< y^2; x > y^2 = True" do
+        expect(Monomial(c=1, p={"x"=>1}).lex(Monomial(c=1, p={"y"=>2}))).to eq 1
+      end
+      it "1 -< x; x > 1 = False" do
+        expect(Monomial(c=1, p={"x"=>1}).lex(Monomial(c=1))).to eq -1
+      end
+      it "x^1*y^2 -< y^3*z^4; x^1*y^2 > y^3*z^4 = True" do
+        expect(Monomial(c=1, p={"x"=>1, "y"=>2}).lex(Monomial(c=1, {"y"=>3, "z"=>4}))).to eq 1
+      end
+    end
+
+    context "Give variables >= 3, use degree lexicographic order" do
+      it "x^3*y^2*z^4 >- x^3*y^2*z^1; x^3*y^2*z^4 < x^3*y^2*z^1 = False" do
+        expect(Monomial(c=1, p={"x"=>3, "y"=>2, "z"=>4}).
+                 deglex(Monomial(c=1, {"x"=>3, "y"=>2, "z"=>1}))).to eq -1
+      end
+    end
   end
 
   describe "#power_product" do

--- a/spec/poly_ruby/monomial_spec.rb
+++ b/spec/poly_ruby/monomial_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe Monomial do
   describe "#lex(m)" do
 
     context "Give 1 or 2 variable, use lexicographic order" do
-      it "1 -< y; 1 > y = True" do
-        expect(Monomial(c=1).lex(Monomial(c=1, p={"y"=>1}))).to eq 1
+      it "1 -< y; 1 < y = True" do
+        expect(Monomial(c=1).lex(Monomial(c=1, p={"y"=>1}))).to eq -1
       end
-      it "y -< y^2; y > y^2 = True" do
-        expect(Monomial(c=1, p={"y"=>1}).lex(Monomial(c=1, p={"y"=>2}))).to eq 1
+      it "y -< y^2; y < y^2 = True" do
+        expect(Monomial(c=1, p={"y"=>1}).lex(Monomial(c=1, p={"y"=>2}))).to eq -1
       end
       it "x -< y; x > y = True" do
         expect(Monomial(c=1, p={"x"=>1}).lex(Monomial(c=1, p={"y"=>1}))).to eq 1
@@ -36,8 +36,8 @@ RSpec.describe Monomial do
       it "x -< y^2; x > y^2 = True" do
         expect(Monomial(c=1, p={"x"=>1}).lex(Monomial(c=1, p={"y"=>2}))).to eq 1
       end
-      it "1 -< x; x > 1 = False" do
-        expect(Monomial(c=1, p={"x"=>1}).lex(Monomial(c=1))).to eq -1
+      it "1 -< x; 1 > x = True" do
+        expect(Monomial(c=1, p={"x"=>1}).lex(Monomial(c=1))).to eq 1
       end
       it "x^1*y^2 -< y^3*z^4; x^1*y^2 > y^3*z^4 = True" do
         expect(Monomial(c=1, p={"x"=>1, "y"=>2}).lex(Monomial(c=1, {"y"=>3, "z"=>4}))).to eq 1

--- a/spec/poly_ruby/monomial_spec.rb
+++ b/spec/poly_ruby/monomial_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe Monomial do
     end
 
     context "Give variables >= 3, use degree lexicographic order" do
-      it "x^3*y^2*z^4 >- x^3*y^2*z^1; x^3*y^2*z^4 < x^3*y^2*z^1 = False" do
+      it "x^3*y^2*z^4 >- x^3*y^2*z^1; x^3*y^2*z^4 > x^3*y^2*z^1 = True" do
         expect(Monomial(c=1, p={"x"=>3, "y"=>2, "z"=>4}).
-                 deglex(Monomial(c=1, {"x"=>3, "y"=>2, "z"=>1}))).to eq -1
+                 deglex(Monomial(c=1, {"x"=>3, "y"=>2, "z"=>1}))).to eq 1
       end
     end
   end

--- a/spec/poly_ruby/polynomialm_spec.rb
+++ b/spec/poly_ruby/polynomialm_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe PolynomialM do
 
   it "can convert string to m-polynomial" do
     expect(PolynomialM("3x^2/2+5/2*x+7/2").to_s).to eq "3x^(2)/2+5x/2+7/2"
-    expect(PolynomialM("x^2+3x*y+y^3").to_s).to eq "y^(3)+x^(2)+3x*y"
+    expect(PolynomialM("x^2+3x*y+y^3").to_s).to eq "x^(2)+3x*y+y^(3)"
     expect(PolynomialM("(y-1)^3").to_s).to eq "y^(3)-3y^(2)+3y-1"
-    expect(PolynomialM("x+y^2").to_s).to eq "y^(2)+x"
+    expect(PolynomialM("x+y^2").to_s).to eq "x+y^(2)"
   end
 
   it "can do arithmetic operations for m-polynomial" do
@@ -18,7 +18,7 @@ RSpec.describe PolynomialM do
     f2=PolynomialM("(y-1)^3")
     f3=PolynomialM("x+y^2")
     f4=f1+f2-2*f3*f1+f3**2
-    expect(f4.to_s).to eq "-2y^(5)-2x^(2)*y^(2)-8x*y^(3)+y^(4)-2x^(3)-6x^(2)*y+2x*y^(2)+2y^(3)+2x^(2)+3x*y-3y^(2)+3y-1"
+    expect(f4.to_s).to eq "-2x^(3)-2x^(2)*y^(2)-6x^(2)*y+2x^(2)-8x*y^(3)+2x*y^(2)+3x*y-2y^(5)+y^(4)+2y^(3)-3y^(2)+3y-1"
   end
 
   describe "#divmod" do
@@ -26,7 +26,7 @@ RSpec.describe PolynomialM do
     f2=PolynomialM("(y-1)^3")
     f3=PolynomialM("x+y^2")
     f4=f1+f2-2*f3*f1+f3**2
-    it "can calc div and modulo" do
+    xit "can calc div and modulo" do
       # divmod supprots multi division.
       # It returns a pair [quotients,residue].
       # In the following sample, We get multi division f4 by f2,f3.
@@ -74,7 +74,7 @@ RSpec.describe PolynomialM do
     it "f(x,y) = x+y^2; ∫ f(x,y) dx dy = x*y^(3)/3+x^(2)*y/2" do
       f3=PolynomialM("x+y^2")
       f7=f3.integral(["x","y"])
-      expect(f7.to_s).to eq "x*y^(3)/3+x^(2)*y/2"
+      expect(f7.to_s).to eq "x^(2)*y/2+x*y^(3)/3"
     end
   end
 end
@@ -109,10 +109,11 @@ RSpec.describe GBase do
         end
       end
       context "with deglex term order" do
-        it do
+        xit do
           Monomial.set_term_order("deglex")
           gbasis=GBase.getGBase([f1,f2])
-          expect(gbasis.map(&:to_s)).to match ["z^(4)+x*y^(2)", "x^(2)*y-y*z/3"]
+          p gbasis.map(&:to_s)
+          expect(gbasis.map(&:to_s)).to match ["x*y^(2)+z^(4)", "x^(2)*y-y*z/3"]
         end
       end
     end
@@ -123,7 +124,7 @@ RSpec.describe GBase do
       f1=PolynomialM("x^2+y^2+1")
       f2=PolynomialM("x^2y+2x*y+x")
 
-      it do
+      xit do
         gbasis=GBase.getGBaseZp([f1,f2],5)
         expect(gbasis.map(&:to_s)).to match ["y^(3)+3x*y+4x+y", "x^(2)+y^(2)+1"]
       end
@@ -137,7 +138,7 @@ RSpec.describe GBase do
       f1=PolynomialM("6x^2+y^2")
       f2=PolynomialM("10x^2y+2x*y")
 
-      it do
+      xit do
         gbasis=GBaseI.getGBaseI([f1,f2])
         expect(gbasis.map(&:to_s)).to match ["x^(2)*y^(3)+y^(5)+4x*y^(3)+y^(3)",
                                              "2x^(2)*y+2y^(3)-2x*y",

--- a/spec/poly_ruby/polynomialm_spec.rb
+++ b/spec/poly_ruby/polynomialm_spec.rb
@@ -25,15 +25,17 @@ RSpec.describe PolynomialM do
     f1=PolynomialM("x^2+3x*y+y^3")
     f2=PolynomialM("(y-1)^3")
     f3=PolynomialM("x+y^2")
-    f4=f1+f2-2*f3*f1+f3**2
-    xit "can calc div and modulo" do
+    it "can calc div and modulo" do
       # divmod supprots multi division.
       # It returns a pair [quotients,residue].
       # In the following sample, We get multi division f4 by f2,f3.
+      f4=f1+f2-2*f3*f1+f3**2
+      expect(f4.to_s).to eq "-2x^(3)-2x^(2)*y^(2)-6x^(2)*y+2x^(2)" +
+                            "-8x*y^(3)+2x*y^(2)+3x*y-2y^(5)+y^(4)+2y^(3)-3y^(2)+3y-1"
       q,r=f4.divmod([f1,f2])
-      expect(q[0].to_s).to eq "-2y^(2)-2x+y+2"
-      expect(q[1].to_s).to eq "0"
-      expect(r.to_s).to eq "-x^(2)*y-x*y^(2)-3x*y-3y^(2)+3y-1"
+      expect(q[0].to_s).to eq "-2x-2y^(2)+2"
+      expect(q[1].to_s).to eq "y+3"
+      expect(r.to_s).to eq "2x*y^(2)-3x*y+3y^(2)-5y+2"
     end
   end
 
@@ -109,11 +111,10 @@ RSpec.describe GBase do
         end
       end
       context "with deglex term order" do
-        xit do
+        it do
           Monomial.set_term_order("deglex")
           gbasis=GBase.getGBase([f1,f2])
-          p gbasis.map(&:to_s)
-          expect(gbasis.map(&:to_s)).to match ["x*y^(2)+z^(4)", "x^(2)*y-y*z/3"]
+          expect(gbasis.map(&:to_s)).to match ["x^(2)*y-y*z/3", "x*y^(2)+z^(4)", "x*z^(4)+y^(2)*z/3", "y^(4)*z-3z^(8)"]
         end
       end
     end
@@ -124,9 +125,11 @@ RSpec.describe GBase do
       f1=PolynomialM("x^2+y^2+1")
       f2=PolynomialM("x^2y+2x*y+x")
 
-      xit do
+      it do
         gbasis=GBase.getGBaseZp([f1,f2],5)
-        expect(gbasis.map(&:to_s)).to match ["y^(3)+3x*y+4x+y", "x^(2)+y^(2)+1"]
+        expect(gbasis.map(&:to_s)).to match ["x^(2)+y^(2)+1",
+                                             "x*y+3x+2y^(3)+2y",
+                                             "y^(5)+2y^(4)+4y^(2)+4y+2"]
       end
     end
   end
@@ -138,12 +141,13 @@ RSpec.describe GBase do
       f1=PolynomialM("6x^2+y^2")
       f2=PolynomialM("10x^2y+2x*y")
 
-      xit do
+      it do
         gbasis=GBaseI.getGBaseI([f1,f2])
-        expect(gbasis.map(&:to_s)).to match ["x^(2)*y^(3)+y^(5)+4x*y^(3)+y^(3)",
-                                             "2x^(2)*y+2y^(3)-2x*y",
-                                             "5y^(3)-6x*y",
-                                             "6x^(2)+y^(2)"]
+        expect(gbasis.map(&:to_s)).to match ["2x^(2)*y+4x*y-3y^(3)",
+                                             "6x^(2)+y^(2)",
+                                             "x*y^(3)+20y^(5)+5y^(3)",
+                                             "6x*y-5y^(3)",
+                                             "25y^(5)+6y^(3)"]
       end
     end
   end

--- a/spec/poly_ruby_spec.rb
+++ b/spec/poly_ruby_spec.rb
@@ -1,4 +1,6 @@
 require "poly_ruby/polynomial"
+require "poly_ruby/polynomialm"
+require "poly_ruby/poly_work"
 require "poly_ruby/elapse"
 
 RSpec.describe PolyRuby do
@@ -15,4 +17,30 @@ RSpec.describe PolyRuby do
     expect(n).to eq 128
     expect(f1==f2).to be true
   end
+
+  context "f(x) = x^5-2y*x^2+y^5, g(x) = x^2-x^2-1" do
+
+    f=PolynomialM(PolyWork.cnv_prog_format("x^5-2y*x^2+y^5"))
+    g=PolynomialM(PolyWork.cnv_prog_format("x^2-y^2-1"))
+    f.sort!(:lex)
+    g.sort!(:lex)
+
+    it "HT(f) = x^5, HC(f) = 1" do
+      expect(f.ht.to_s).to eq "x^(5)"
+      expect(f.hc.to_s).to eq "1"
+    end
+    it "HT(g) = x^2, HC(g) = 1" do
+      expect(g.ht.to_s).to eq "x^(2)"
+      expect(g.hc.to_s).to eq "1"
+    end
+    it "spoly(f,g) = " do
+      ht_f=f.ht
+      ht_g=g.ht
+      hm_f=f.ht
+      hm_g=g.ht
+
+      #p (ht_f.lcm(ht_g)/hm_f)*f - (ht_f.lcm(ht_g)/hm_g)*g
+    end
+  end
+
 end

--- a/spec/poly_ruby_spec.rb
+++ b/spec/poly_ruby_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe PolyRuby do
     f.sort!(:lex)
     g.sort!(:lex)
 
+    ht_f=f.ht
+    ht_g=g.ht
+    hm_f=f.ht
+    hm_g=g.ht
+
     it "HT(f) = x^5, HC(f) = 1" do
       expect(f.ht.to_s).to eq "x^(5)"
       expect(f.hc.to_s).to eq "1"
@@ -33,14 +38,19 @@ RSpec.describe PolyRuby do
       expect(g.ht.to_s).to eq "x^(2)"
       expect(g.hc.to_s).to eq "1"
     end
-    it "spoly(f,g) = " do
-      ht_f=f.ht
-      ht_g=g.ht
-      hm_f=f.ht
-      hm_g=g.ht
-
-      #p (ht_f.lcm(ht_g)/hm_f)*f - (ht_f.lcm(ht_g)/hm_g)*g
+    it "lcm(HT(f), HT(g)) = x^5" do
+      expect(ht_f.lcm(ht_g).to_s).to eq "x^(5)"
     end
-  end
+    it "lcm(HT(f), HT(g))*f/HM(f) = x^5-2x^2*y+y^5" do
+      expect((ht_f.lcm(ht_g)*f/hm_f).to_s).to eq "x^(5)-2x^(2)*y+y^(5)"
+    end
+    it "lcm(HT(f), HT(g))*f/HM(g) = x^5-x^3*y^2-x^3" do
+      expect((ht_f.lcm(ht_g)*g/hm_g).to_s).to eq "x^(5)-x^(3)*y^(2)-x^(3)"
+    end
+    it "spoly(f,g) = x^3*y^2+x^3-2x^2*y+y^5" do
+      expect(((ht_f.lcm(ht_g)*f/hm_f) - (ht_f.lcm(ht_g)*g/hm_g)).to_s).
+        to eq "x^(3)*y^(2)+x^(3)-2x^(2)*y+y^(5)"
+    end
 
+  end
 end


### PR DESCRIPTION
ref #1 

## 対応内容
- 項順序のキーを文字列からシンボルに変えた `:lex(default), :deglex,  :degrevlex`
- エイリアスの便利メソッドとして `ht (head term)`, `hc (head coefficient)` を追加

### 項順序について

#### 辞書式順序 (lexicographic order, lex) の数学的な前提

>β - α の 0 でない最初の成分が正である場合に x^α < x^β として定義される単項式順序である。
>素朴に表現するならば、lex 順序はまず最も「上位の」不定元の指数の大きさによって順序付け、
>それが同じものについては順次「下位の」不定元の指数の大きさによって順序付ける。 

先に、xとyについて辞書式順序の例を挙げると以下のようになる

![1 \prec y \prec y^2 \prec \cdots \prec x \prec xy \prec xy^2 \prec \cdots x^2 \prec x^2y \prec \cdots x^3 \cdots](https://render.githubusercontent.com/render/math?math=%5CLARGE+%5Cdisplaystyle+1+%5Cprec+y+%5Cprec+y%5E2+%5Cprec+%5Ccdots+%5Cprec+x+%5Cprec+xy+%5Cprec+xy%5E2+%5Cprec+%5Ccdots+x%5E2+%5Cprec+x%5E2y+%5Cprec+%5Ccdots+x%5E3+%5Ccdots)

解説なしに≺を使ったが、「グレブナー基底の計算 基礎編 計算代数入門」, p82 より以下のようなことが言える

>集合における順序≺とは大小関係を一般化したものと考えてよい

Wolframへのリンクを引用：

- [Precedes](https://mathworld.wolfram.com/Precedes.html)
    - The relationship x precedes y is written x≺y. The relation x precedes or is equal to y is written x<=y.
    - xがyに先行する関係はx≺yと書かれています。 関係xはyに先行するか、yに等しいと、x <= yと記述されます。
- [Succeeds](https://mathworld.wolfram.com/Succeeds.html)
    - The relationship x succeeds (or follows) y is written x≻y. The relation x succeeds or is equal to y is written x>=y. 
    - 関係xは〜に続きます yはx≻yと書かれます。 関係xは続くか、yと等しいとx> = yと記述されます。

もう一度例に戻ると

![1 \prec y \prec y^2 \prec \cdots \prec x \prec xy \prec xy^2 \prec \cdots x^2 \prec x^2y \prec \cdots x^3 \cdots](https://render.githubusercontent.com/render/math?math=%5CLARGE+%5Cdisplaystyle+1+%5Cprec+y+%5Cprec+y%5E2+%5Cprec+%5Ccdots+%5Cprec+x+%5Cprec+xy+%5Cprec+xy%5E2+%5Cprec+%5Ccdots+x%5E2+%5Cprec+x%5E2y+%5Cprec+%5Ccdots+x%5E3+%5Ccdots)

- 例からわかる暗黙の前提
    - このprecedes/succeedsは、集合を昇順/降順(asc/desc)で見たとき昇順(asc)で先行しているという意味を前提として持っているようだ。昇順(asc)は小さいものが先にくる。
    - また、y ≺ xが先に定義されている←これは単にXのほうがYより大きいということ

#### 辞書式順序 (lexicographic order, lex) の実装のメモ書き

さて、順序が定義できたところでどういう風にしたいか考えると

- さっきの例の逆で項は並んでほしいので、ソートしたら降順(desc)になってほしい
    - まあRubyの[Array#sort](https://docs.ruby-lang.org/ja/latest/method/Enumerable/i/sort.html)はデフォルトで昇順である

![x^3, x^2y, x^2, xy^2, xy, x, y^2, y, 1 (= x^0y^0)](https://render.githubusercontent.com/render/math?math=%5CLARGE+%5Cdisplaystyle+x%5E3%2C+x%5E2y%2C+x%5E2%2C+xy%5E2%2C+xy%2C+x%2C+y%5E2%2C+y%2C+1+%28%3D+x%5E0y%5E0%29)

- 項順序は任意で定義したい
    - ただ、普通のアルファベット順だとaとかbがx,yより前に来てしまうので、x, y, zのようなよく使うやつは大きいものと定義しておこう

![x \succ y \succ z \succ u \succ v \succ w \succ p \succ q \succ r \succ s \succ t \succ a \succ b \succ c \succ d \succ e \succ f \succ g \succ h \succ i \succ j \succ k \succ l \succ m \succ n \succ o](https://render.githubusercontent.com/render/math?math=%5CLARGE+%5Cdisplaystyle+x+%5Csucc+y+%5Csucc+z+%5Csucc+u+%5Csucc+v+%5Csucc+w+%5Csucc+p+%5Csucc+q+%5Csucc+r+%5Csucc+s+%5Csucc+t+%5Csucc+a+%5Csucc+b+%5Csucc+c+%5Csucc+d+%5Csucc+e+%5Csucc+f+%5Csucc+g+%5Csucc+h+%5Csucc+i+%5Csucc+j+%5Csucc+k+%5Csucc+l+%5Csucc+m+%5Csucc+n+%5Csucc+o)

- 実装
    - ソート対象の係数は無いものとして考える
    - ソート対象の多項式は"変数を文字列、べき指数を数値としてもつ連想配列"として考える